### PR TITLE
DEVL 70 - select single dataset mutliple times for Job

### DIFF
--- a/src/app/layout/datasets/confirm-datasets.modal.component.ts
+++ b/src/app/layout/datasets/confirm-datasets.modal.component.ts
@@ -1,13 +1,10 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { DownloadOptions, JobDownload } from '../../shared/modules/vgl/models';
 import { DownloadOptionsModalContent } from './download-options.modal.component';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TreeNode } from 'primeng/api';
 import { VglService } from '../../shared/modules/vgl/vgl.service';
 import { UserStateService } from '../../shared';
-import { HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 

--- a/src/app/layout/datasets/confirm-datasets.modal.component.ts
+++ b/src/app/layout/datasets/confirm-datasets.modal.component.ts
@@ -176,7 +176,9 @@ export class ConfirmDatasetsModalContent {
                 forkJoin(makeUrls).subscribe(results => {
                     this.capturedJobDownloadCount = results.length;
                     // Persist data selections to user state service
-                    this.userStateService.setJobDownloads(<JobDownload[]>results);
+                    for(let result of results) {
+                        this.userStateService.addJobDownload(<JobDownload>result);
+                    }
                     // Display selection OK modal
                     this.modalService.open(this.selectedDatasetsOkModal);
                     this.activeModal.close();

--- a/src/app/layout/datasets/download-options.modal.component.ts
+++ b/src/app/layout/datasets/download-options.modal.component.ts
@@ -14,7 +14,7 @@ import { VglService } from '../../shared/modules/vgl/vgl.service';
 
 export class DownloadOptionsModalContent implements OnInit {
 
-    // TODO: We may want to move these if needed by other classes
+    // Validator patterns
     LATITUDE_PATTERN = '^(\\+|-)?(?:90(?:(?:\\.0{1,20})?)|(?:[0-9]|[1-8][0-9])(?:(?:\\.[0-9]{1,20})?))$';
     LONGITUDE_PATTERN = '^(\\+|-)?(?:180(?:(?:\\.0{1,20})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\\.[0-9]{1,20})?))$';
 
@@ -165,8 +165,6 @@ export class DownloadOptionsModalContent implements OnInit {
                 }
             }
             this.activeModal.close();
-        } else {
-
         }
     }
     

--- a/src/app/layout/datasets/openlayermap/controls/olmap.select.data.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.select.data.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { ConfirmDatasetsModalContent } from '../../confirm-datasets.modal.component';
-import { UserStateService } from '../../../../shared';
 import { DownloadOptions } from '../../../../shared/modules/vgl/models';
 import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
 import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
@@ -8,7 +7,6 @@ import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.mo
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TreeNode } from 'primeng/api';
 import olExtent from 'ol/extent';
-import olLayer from 'ol/layer/layer';
 import olProj from 'ol/proj';
 
 
@@ -49,7 +47,6 @@ export class OlMapDataSelectComponent {
 
 
     constructor(private olMapService: OlMapService,
-        private userStateService: UserStateService,
         private modalService: NgbModal) { }
 
 
@@ -75,13 +72,6 @@ export class OlMapDataSelectComponent {
             // Display confirm datasets modal
             if (cswRecords.length > 0) {
                 const modelRef = this.modalService.open(ConfirmDatasetsModalContent, { size: 'lg' });
-                /*
-                this.userStateService.datasetDownloads.subscribe(
-                    datasetDownloads => {
-                        modelRef.componentInstance.cswRecordTreeData = this.buildTreeData(cswRecords, extent, datasetDownloads);
-                    }
-                );
-                */
                 modelRef.componentInstance.cswRecordTreeData = this.buildTreeData(cswRecords, extent);
             }
             this.buttonText = 'Select Data';
@@ -90,6 +80,8 @@ export class OlMapDataSelectComponent {
 
 
     /**
+     * Return a count of the active layers on the map
+     * 
      * TODO: This is used elsewhere, should make a map service method
      */
     public getActiveLayerCount(): number {
@@ -129,6 +121,7 @@ export class OlMapDataSelectComponent {
 
 
     /**
+     * Create default download options for a given online resource
      * 
      * @param or 
      * @param cswRecord 
@@ -205,6 +198,7 @@ export class OlMapDataSelectComponent {
 
 
     /**
+     * Is the online resource of a supported type
      * 
      * @param onlineResource 
      */
@@ -222,10 +216,9 @@ export class OlMapDataSelectComponent {
 
 
     /**
-     * Builds TreeTable from supplied CSWRecords
+     * Builds TreeTable from supplied CSWRecords for display in the confirm
+     * datasets modal
      *
-     * TODO: Currently only looks at NCSS data
-     * 
      * @param cswRecords list of CSWRecords from which to construct a list of
      *                   TreeNodes
      * @param region the user selected region, may be the entire CSWRecord
@@ -260,28 +253,6 @@ export class OlMapDataSelectComponent {
             }
 
             for (let record of cswRecords) {
-
-                // See if this record has already been selected
-                /*
-                const datasetDownload = datasetDownloads.find(dataDl => dataDl.cswRecord === record);
-                if(datasetDownload) {
-                    console.log("Adding existing DL to tree");
-                    let node: TreeNode = {};
-                    node.data = {
-                        "name": datasetDownload.onlineResource.name,
-                        "url": datasetDownload.onlineResource.url,
-                        "cswRecord": datasetDownload.cswRecord,
-                        "onlineResource": datasetDownload.onlineResource,
-                        "downloadOptions": datasetDownload.downloadOptions,
-                        "leaf": true
-                    }
-                    
-                    //node.selected = true;
-                    const rootResourceNode = resourceTypeNodes.find(node => node.data['id'] === datasetDownload.onlineResource.type);
-                    if(rootResourceNode) {
-                        rootResourceNode.children.push(node);
-                    }
-                }*/
                 let foundResourceTypeForRecord: boolean = false;
                 for (let resourceType in this.onlineResources) {
                     let rootResourceNode = resourceTypeNodes.find(node => node.data['id'] === resourceType);

--- a/src/app/layout/jobs/submission/job-submission-datasets.component.ts
+++ b/src/app/layout/jobs/submission/job-submission-datasets.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TreeJobs, TreeJobNode, JobDownload, JobFile, CloudFileInformation } from '../../../shared/modules/vgl/models';
+import { JobDownload, CloudFileInformation } from '../../../shared/modules/vgl/models';
 import { UserStateService } from '../../../shared';
 import { JobInputsBrowserModalContent } from './job-inputs-browser.modal.component';
 import { TreeNode } from 'primeng/api';
@@ -195,7 +195,7 @@ export class JobSubmissionDatasetsComponent {
         );
 
         // Job files copied from jobs
-        const copiedJobFiles = this.userStateService.jobCloudFiles.subscribe(
+        this.userStateService.jobCloudFiles.subscribe(
             jobCloudFiles => {
                 for (const jobFile of jobCloudFiles) {
                     this.addJobCloudFileToTree(jobFile);
@@ -265,7 +265,7 @@ export class JobSubmissionDatasetsComponent {
     private deleteSelectedInput(): void {
         if (this.selectedJobInputNode.parent.data.id === 'upload') {
             if (this.selectedJobInputNode.data.input.hasOwnProperty('cloudKey')) {
-                this.userStateService.removeCloudFile(this.selectedJobInputNode.data.input);
+                this.userStateService.removeJobCloudFile(this.selectedJobInputNode.data.input);
             } else {
                 this.userStateService.removeUploadedFile(this.selectedJobInputNode.data.input);
             }
@@ -290,7 +290,7 @@ export class JobSubmissionDatasetsComponent {
                     }
                     for (let cloudFile of result.jobCloudFiles) {
                         cloudFile.jobId = result.jobId;
-                        this.userStateService.addCloudFile(cloudFile);
+                        this.userStateService.addJobCloudFile(cloudFile);
                     }
                     // TODO: Can probably just add new ones instead of full reload,
                     // but will help keep in sync until better logic is added

--- a/src/app/shared/services/user-state.service.ts
+++ b/src/app/shared/services/user-state.service.ts
@@ -1,13 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 
 import { ANONYMOUS_USER, Solution, SolutionQuery, User, NCIDetails, JobDownload, CloudFileInformation } from '../modules/vgl/models';
 import { VglService } from '../modules/vgl/vgl.service';
-
-import { environment } from '../../../environments/environment';
 
 import { saveAs } from 'file-saver/FileSaver';
 
@@ -166,13 +163,13 @@ export class UserStateService {
     this._jobCloudFiles.next(jobCloudFiles);
   }
 
-  public addCloudFile(cloudFile: CloudFileInformation) {
+  public addJobCloudFile(cloudFile: CloudFileInformation) {
       let cloudFiles: CloudFileInformation[] = this._jobCloudFiles.getValue();
       cloudFiles.push(cloudFile);
       this._jobCloudFiles.next(cloudFiles);
   }
 
-  public removeCloudFile(cloudFile: CloudFileInformation): void {
+  public removeJobCloudFile(cloudFile: CloudFileInformation): void {
     let cloudFiles: any[] = this._jobCloudFiles.getValue();
     cloudFiles.forEach((item, index) => {
       if(item === cloudFile) {


### PR DESCRIPTION
Allow a single dataset to be added to a Job multiple times with different download options.

https://jira.csiro.au/browse/DEVL-70

To test:

* Add a dataset to the map.
* Capture an area of that dataset, confirm it has been added to the New Job inputs.
* Return to map, capture a different area of the same dataset. In DL options, modify the location.
* Return to New Job and confirm that the same dataset has been added twice, and that the modified location is different to the first.
