### PR TITLE
Add Layer button (Datasets) adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ol": "^4.3.1",
     "portal-core-ui": "stuartwoodman/portal-core-ui",
     "primeicons": "1.0.0-beta.7",
-    "primeng": "6.0.0-rc.1",
+    "primeng": "^6.1.2",
     "rxjs": "^6.2.2",
     "rxjs-compat": "^6.0.0-rc.0",
     "simplify": "^1.0.0",

--- a/src/app/layout/datasets/datasets-display.component.html
+++ b/src/app/layout/datasets/datasets-display.component.html
@@ -1,45 +1,45 @@
 <div class="row">
     <div class="col" style="padding: 0px;">
         <li *ngFor="let cswRecord of cswRecordList">
-                <div class="input-group input-group-sm">
-                    <span class="input-group-prepend" style="display:flex">                        
-                        <button *ngIf="!cswRecord.hasOwnProperty('onlineResources') || cswRecord.onlineResources.length==0" class="btn btn-sm" data-toggle="tooltip"
-                            title="Layer has no associated online resources and as such, cannot be added">
-                            <i class="fa fa-times"></i>
+            <div class="input-group input-group-sm">
+                <span class="input-group-prepend" style="display:flex">                        
+                    <button *ngIf="!canRecordBeAdded(cswRecord) && !olMapService.layerExists(cswRecord.id)" class="btn btn-sm" data-toggle="tooltip"
+                        title="Layer has no associated online resources and as such, cannot be added">
+                        <i class="fa fa-times"></i>
+                    </button>
+                    <button *ngIf="canRecordBeAdded(cswRecord)"
+                        class="btn btn-sm" data-toggle="tooltip" title="Add layer to map"
+                        (click)="addCSWRecord(cswRecord)">
+                        <i class="fa fa-plus-circle" style="color:green;"></i>
+                    </button>
+                    <button *ngIf="olMapService.layerExists(cswRecord.id)" class="btn btn-sm" data-toggle="tooltip" title="Remove layer from map"
+                        (click)="removeCSWRecord(cswRecord.id)">
+                        <i class="fa fa-trash" style="color:red;"></i>
+                    </button>
+                    <div >
+                        <button *ngIf="validUser && !isBookMark(cswRecord)" class="btn btn-sm" data-toggle="tooltip" title="Bookmark as favourite" (click)="addBookMark(cswRecord)">
+                            <i class="fa fa-heart-o" style="color:red;"></i>
                         </button>
-                        <button *ngIf="cswRecord.hasOwnProperty('onlineResources') && cswRecord.onlineResources.length>0 && !olMapService.layerExists(cswRecord.id)"
-                            class="btn btn-sm" data-toggle="tooltip" title="Add layer to map"
-                            (click)="addCSWRecord(cswRecord)">
-                            <i class="fa fa-plus-circle" style="color:green;"></i>
+                        <button *ngIf="validUser && isBookMark(cswRecord)" class="btn btn-sm" data-toggle="tooltip" title="Remove as favourite" (click)="removeBookMark(cswRecord)">                                    
+                                <i class="fa fa-heart" style="color:red;"></i>
                         </button>
-                        <button *ngIf="olMapService.layerExists(cswRecord.id)" class="btn btn-sm" data-toggle="tooltip" title="Remove layer from map"
-                            (click)="removeCSWRecord(cswRecord.id)">
-                            <i class="fa fa-trash" style="color:red;"></i>
-                        </button>
-                        <div >
-                            <button *ngIf="validUser && !isBookMark(cswRecord)" class="btn btn-sm" data-toggle="tooltip" title="Bookmark as favourite" (click)="addBookMark(cswRecord)">
-                                <i class="fa fa-heart-o" style="color:red;"></i>
-                            </button>
-                            <button *ngIf="validUser && isBookMark(cswRecord)" class="btn btn-sm" data-toggle="tooltip" title="Remove as favourite" (click)="removeBookMark(cswRecord)">                                    
-                                    <i class="fa fa-heart" style="color:red;"></i>
-                            </button>
-                        </div>
-                    </span>
-                    <label class="input-group-label text-truncate" data-toggle="tooltip" title="{{ cswRecord.name }}" readonly style="width: 100%;">
-                        {{ cswRecord.name }}
-                    </label>
-                    <span class="input-group-append">
-                        <button class="btn btn-sm" data-toggle="tooltip" title="Click to display layer information" (click)="displayRecordInformation(cswRecord)">
-                            <i class="fa fa-info-circle" style="color:blue;"></i>
-                        </button>
-                    </span>
-                    <span class="input-group-append" *ngIf="cswRecord.hasOwnProperty('geographicElements') && cswRecord.geographicElements.length>0">                        
-                        <button class="btn btn-sm" data-toggle="tooltip" title="Display layer bounds, double-click to zoom to bounds" (click)="showCSWRecordBounds(cswRecord)"
-                            (dblclick)="zoomToCSWRecordBounds(cswRecord)">
-                            <i class="fa fa-search"></i>
-                        </button>
-                    </span>
-                </div>
-            </li> 
+                    </div>
+                </span>
+                <label class="input-group-label text-truncate" data-toggle="tooltip" title="{{ cswRecord.name }}" readonly style="width: 100%;">
+                    {{ cswRecord.name }}
+                </label>
+                <span class="input-group-append">
+                    <button class="btn btn-sm" data-toggle="tooltip" title="Click to display layer information" (click)="displayRecordInformation(cswRecord)">
+                        <i class="fa fa-info-circle" style="color:blue;"></i>
+                    </button>
+                </span>
+                <span class="input-group-append" *ngIf="cswRecord.hasOwnProperty('geographicElements') && cswRecord.geographicElements.length>0">                        
+                    <button class="btn btn-sm" data-toggle="tooltip" title="Display layer bounds, double-click to zoom to bounds" (click)="showCSWRecordBounds(cswRecord)"
+                        (dblclick)="zoomToCSWRecordBounds(cswRecord)">
+                        <i class="fa fa-search"></i>
+                    </button>
+                </span>
+            </div>
+        </li> 
     </div>
 </div>

--- a/src/app/layout/datasets/datasets-display.component.ts
+++ b/src/app/layout/datasets/datasets-display.component.ts
@@ -9,6 +9,9 @@ import olProj from 'ol/proj';
 import olExtent from 'ol/extent';
 
 
+// List of valid online resource types that can be added to the map
+const VALID_ONLINE_RESOURCE_TYPES: string[] = ['WMS', 'WFS', 'CSW', 'WWW'];
+
 @Component({
     selector: 'app-datasets-display',
     templateUrl: './datasets-display.component.html',
@@ -21,7 +24,7 @@ export class DatasetsDisplayComponent {
     @Input() bookMarkList: BookMark[] = []; 
     @Input() validUser = false;
     
-    @Output() bookMarkChoice = new EventEmitter();    
+    @Output() bookMarkChoice = new EventEmitter();   
 
     constructor(private olMapService: OlMapService,
         private cswSearchService: CSWSearchService,        
@@ -124,5 +127,24 @@ export class DatasetsDisplayComponent {
         }, error => {            
             console.log(error.message);
         });
+    }
+
+    /**
+     * Determine if a CSWRecord meets the criteria to be added to the map:
+     * 
+     *   1. Has online resource.
+     *   2. Has at least one defined geographicElement.
+     *   3. Layer does not already exist on map.
+     *   4. One online resource is of type WMS, WFS, CSW or WWW.
+     * 
+     * @param cswRecord the CSWRecord to verify
+     * @return true is CSWRecord can be added, false otherwise
+     */
+    public canRecordBeAdded(cswRecord: CSWRecordModel): boolean {
+        return cswRecord.hasOwnProperty('onlineResources') &&
+               cswRecord.onlineResources.length > 0 &&
+               cswRecord.geographicElements.length > 0 &&
+               !this.olMapService.layerExists(cswRecord.id) &&
+               cswRecord.onlineResources.some(resource => VALID_ONLINE_RESOURCE_TYPES.indexOf(resource.type) > -1);
     }
 }

--- a/src/app/layout/datasets/datasets.component.ts
+++ b/src/app/layout/datasets/datasets.component.ts
@@ -28,7 +28,6 @@ export class DatasetsComponent implements OnInit, AfterViewChecked {
 
     // Search results   
     cswSearchResults: CSWRecordModel[] = [];
-    //selectedCSWRecord = null;
     recordsLoading = false;
 
     //BookMarks    

--- a/src/app/layout/jobs/submission/job-submission-datasets.component.html
+++ b/src/app/layout/jobs/submission/job-submission-datasets.component.html
@@ -3,9 +3,9 @@
     <!-- TODO: Unsure where this will sit, if it's a full pager style body to fill vertically using calc -->
     <div class="card-body datasetsTablePanel">
         <div style="margin:10px;" *ngIf="jobInputNodes.length === 0">
-            This doesn't have any input files or service downloads configured. You can add some by using the add button below or by selecting
+            This job doesn't have any input files or service downloads configured. You can add some by using the add button below or by selecting
             a dataset from the
-            <a href="/data">datasets page</a>.
+            <a [routerLink]="['/data']">datasets page</a>.
         </div>
         <!-- TODO: Actions currently via context menu, do we need an action column to match some other tables? -->
         <p-treeTable *ngIf="jobInputNodes.length > 0" [value]="jobInputNodes" [columns]="treeCols" [resizableColumns]="true" selectionMode="single"


### PR DESCRIPTION
* A layer can now only be added to the map provided it passes the following checks:

  1. CSWRecord has on online resource.
  2. CSWRecord has at least one geographic element displayed.
  3. CSWRecord is not already on the map.
  4. At least one online resource is of a valid type supported by current version of portal-core-ui (WMS, WFS, CSW, WWW).

* Minor adjustment to job submission page to use a router link instead of a page link (to /data when there are no datasets) to prevent the page reloading.