### PR TITLE
Update job object with machine image run command

### DIFF
--- a/src/app/layout/job-wizard/job-object.component.ts
+++ b/src/app/layout/job-wizard/job-object.component.ts
@@ -92,27 +92,35 @@ export class JobObjectComponent implements OnDestroy, OnInit {
 
           // Select the first image in the list by default, and update resources accordingly.
           if (this.toolboxes.length > 0) {
-            const computeVmId = this.toolboxes[0].imageId;
-            this.job.computeVmId = computeVmId;
-            this.toolboxChanged(computeVmId);
+            const toolbox = this.toolboxes[0];
+            this.job.computeVmId = toolbox.imageId;
+            this.toolboxChanged(toolbox);
           }
         });
     }
   }
 
   /**
-   * When toolbox is changed and we're using a cloud compute provider, reload
-   * the available cloud resources.
+   * Update when user selects a toolbox.
    *
    * @param event the toolbox select change event
    */
-  public toolboxChanged(toolbox): void {
-    if (this.isCloudProvider(this.job.computeServiceId)) {
-      if(toolbox && toolbox !== "") {
-        this.vgl.getComputeTypes(this.job.computeServiceId, toolbox)
-          .subscribe(computeTypes => {
-            this.resources = computeTypes;
-          });
+  public toolboxChanged(imageId): void {
+    const toolbox = this.toolboxes.find(it => it.imageId == imageId);
+
+    if (toolbox) {
+      // Set the computeVmRunCommand on the job to match the new toolbox.
+      this.job.computeVmRunCommand = toolbox.runCommand;
+
+      // When toolbox is changed and we're using a cloud compute provider, reload
+      // the available cloud resources.
+      if (this.isCloudProvider(this.job.computeServiceId)) {
+        if(imageId && imageId !== "") {
+          this.vgl.getComputeTypes(this.job.computeServiceId, imageId)
+            .subscribe(computeTypes => {
+              this.resources = computeTypes;
+            });
+        }
       }
     }
   }

--- a/src/app/layout/job-wizard/job-object.component.ts
+++ b/src/app/layout/job-wizard/job-object.component.ts
@@ -94,7 +94,7 @@ export class JobObjectComponent implements OnDestroy, OnInit {
           if (this.toolboxes.length > 0) {
             const toolbox = this.toolboxes[0];
             this.job.computeVmId = toolbox.imageId;
-            this.toolboxChanged(toolbox);
+            this.toolboxChanged(toolbox.imageId);
           }
         });
     }

--- a/src/app/shared/modules/vgl/vgl.service.ts
+++ b/src/app/shared/modules/vgl/vgl.service.ts
@@ -320,9 +320,11 @@ export class VglService {
     // Copy the properties of the job for the request parameters.
     const params = {...job};
 
-    // Remove any properties that are undefined, so they do not get included in
-    // the request parameters.
+    // Update params object so that it's properties match the parameters
+    // expected by the server.
     for (const p of Object.getOwnPropertyNames(job)) {
+      // Remove any properties that are undefined, so they do not get included in
+      // the request parameters.
       if (params[p] == undefined) {
         delete params[p];
       }


### PR DESCRIPTION
Depends on an updated VGL backend from this pull request: https://github.com/AuScope/ANVGL-Portal/pull/159.

Hopefully completes DEVL-86. Updates job object with run command from the mchine image (e.g. the escript toolbox on raijin requires a special wrapper instead of just invoking python), and passes it to VGL when updating the job.

