### PR TITLE
Display compute type description, use id if no description.

### DIFF
--- a/src/app/layout/job-wizard/job-object.component.html
+++ b/src/app/layout/job-wizard/job-object.component.html
@@ -63,7 +63,7 @@
             <div class="col-lg-10">
                 <div class="input-group">
                     <select style="width:100%;" [(ngModel)]="job.computeTypeId">
-                        <option *ngFor="let resource of resources" [value]="resource.id">{{ resource.id }}</option>
+                        <option *ngFor="let resource of resources" [value]="resource.id">{{ resource.description }}</option>
                     </select>
                 </div>
                 <small>Select a compute resource configuration that is sufficient for your needs.</small>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6018,7 +6018,7 @@ pkg-dir@^2.0.0:
 
 portal-core-ui@stuartwoodman/portal-core-ui:
   version "0.0.1"
-  resolved "https://codeload.github.com/stuartwoodman/portal-core-ui/tar.gz/7f27882de879b45709ecc6b79e1c7a9fe845bac3"
+  resolved "https://codeload.github.com/stuartwoodman/portal-core-ui/tar.gz/536c0214afce0ea830c7f78e7d8f32864e7c1597"
 
 portfinder@^1.0.13, portfinder@^1.0.9:
   version "1.0.17"


### PR DESCRIPTION
Display compute type descriptions in job wizard instead of ids. VGL doesn't always provide descriptions (e.g. with AWS), so on loading compute types from VGL fill in missing descriptions with ids.

Also includes the package version bump in yarn.lock corresponding to the latest portal-core-ui upgrade.