### PR TITLE
DEVL-123 Fix redirect after login

### DIFF
--- a/src/app/layout/user/user-management.component.ts
+++ b/src/app/layout/user/user-management.component.ts
@@ -115,11 +115,9 @@ export class UserManagementComponent implements OnInit {
      * User has accepted T&C's. Leverage existing AWS function to write this back to DB
      */
     private acceptTermsAndConditions(): void {
-      this.userStateService.setUserAwsDetails(this.user.arnExecution, this.user.arnStorage, 1, this.user.awsKeyName).subscribe(
-        result => {
-          this.userStateService.updateUser();
-        }
-      );
+      this.userStateService.setUserAwsDetails(this.user.arnExecution, this.user.arnStorage, 1, this.user.awsKeyName).subscribe(() => {
+          this.userStateService.updateUser().subscribe();
+      });
     }
 
     

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -57,40 +57,40 @@ export class AuthService {
    * the server, but the front end doesn't know it yet
    */
   checkServerLogin(): void {
-    this.userStateService.updateUser();
-    this.userStateService.updateBookMarks();
-    this.userStateService.user.subscribe(
-      user => {
-          if(user === ANONYMOUS_USER) {
-            localStorage.removeItem('isLoggedIn');
-          } else {
-            localStorage.setItem('isLoggedIn', 'true');
-          }
-      }
-    )
+    this.userStateService.updateUser().subscribe(() => {
+        this.userStateService.updateBookMarks();
+        this.userStateService.user.subscribe(user => {
+            if(user === ANONYMOUS_USER) {
+                localStorage.removeItem('isLoggedIn');
+            } else {
+                localStorage.setItem('isLoggedIn', 'true');
+            }
+        })
+    });
   }
 
   onLoggedIn() {
     localStorage.setItem('isLoggedIn', 'true');
     // Trigger an update in the user state service to get the new username
-    this.userStateService.updateUser();
-    // Check is User has accpeted T&C's
-    this.userStateService.user.subscribe(
-        user => {
-            // Navigate to the saved url. Reset the saved url so it isn't retained for
-            // later logins.
-            if(user.acceptedTermsConditions && user.acceptedTermsConditions > 0) {
-                this.userStateService.updateBookMarks();
-                const savedUrl = this.resetRedirectUrl();
-                const redirect = savedUrl ? savedUrl : '/dashboard';
-                this.router.navigate([redirect]);
+    this.userStateService.updateUser().subscribe(() => {
+        // Check is User has accpeted T&C's
+        this.userStateService.user.subscribe(
+            user => {
+                // Navigate to the saved url. Reset the saved url so it isn't retained for
+                // later logins.
+                if(user.acceptedTermsConditions && user.acceptedTermsConditions > 0) {
+                    this.userStateService.updateBookMarks();
+                    const savedUrl = this.resetRedirectUrl();
+                    const redirect = savedUrl ? savedUrl : '/dashboard';
+                    this.router.navigate([redirect]);
+                }
+                // Redirect User to Profile to accept T&C's if they haven't already
+                else {
+                    this.router.navigate(['/user'], { queryParams: { notacs: 1 } });
+                }
             }
-            // Redirect User to Profile to accept T&C's if they haven't already
-            else {
-                this.router.navigate(['/user'], { queryParams: { notacs: 1 } });
-            }
-        }
-    );
+        );
+    });
   }
 
   public get isLoggedIn(): boolean {

--- a/src/app/shared/services/user-state.service.ts
+++ b/src/app/shared/services/user-state.service.ts
@@ -60,9 +60,8 @@ export class UserStateService {
         return this.currentView;
     }
 
-    public updateUser() {
-        this.vgl.user.subscribe(
-            user => {
+    public updateUser(): Observable<any> {
+        return this.vgl.user.map(user => {
                 // If full name is empty (as with AAF login), use email address as name
                 if (user.fullName === undefined || user.fullName === "") {
                     user.fullName = user.email;


### PR DESCRIPTION
If an anonymous User selects a secure page, they are redirected to login. After successful login they should be redirected back to the page they attempted to access. This happened, but the User was then immediately re-redirected to the dashboard. This changes the way UserStateService.updateUser is called so the User changing during login won't cause the subscribe method within AuthServce.onLoggedIn to be called twice (hence redirecting twice).