### PR TITLE
* Moved layer opacity slider to active layers dropdown.

### DIFF
--- a/src/app/layout/datasets/datasets-display.component.html
+++ b/src/app/layout/datasets/datasets-display.component.html
@@ -35,16 +35,6 @@
                         </button>
                 </span>
                 <span class="input-group-append">
-                    <div ngbDropdown>
-                        <button ngbDropdownToggle [disabled]="isRecordAddedToMap(cswRecord) ? null : true" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Layer opacity">
-                            <i class="fa fa-tint"></i>
-                        </button>
-                        <div ngbDropdownMenu>
-                            <p-slider [ngModel]="layerOpacities.get(cswRecord.id)" [min]="0" [max]="100" orientation="vertical" (onChange)="setLayerOpacity(cswRecord.id, $event)"></p-slider>
-                        </div>
-                    </div>
-                </span>
-                <span class="input-group-append">
                     <button class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Click to display layer information" (click)="displayRecordInformation(cswRecord)">
                         <i class="fa fa-info-circle" style="color:blue;"></i>
                     </button>

--- a/src/app/layout/datasets/datasets-display.component.scss
+++ b/src/app/layout/datasets/datasets-display.component.scss
@@ -31,17 +31,3 @@ label {
   height: 24px;
   line-height: 24px;
 }
-
-// Remove opacity Dropdown arrow
-.dropdown-toggle::after {
-  display:none;
-}
-
-.dropdown-menu {
-  min-width: 25px;
-}
-
-p-slider {
-  display: flex;
-  justify-content: center;
-}

--- a/src/app/layout/datasets/datasets-display.component.ts
+++ b/src/app/layout/datasets/datasets-display.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
 import { BookMark } from '../../shared/modules/vgl/models';
 import { RecordModalComponent } from './record.modal.component';
@@ -16,7 +16,7 @@ const VALID_ONLINE_RESOURCE_TYPES: string[] = ['WMS', 'WFS', 'CSW', 'WWW'];
     templateUrl: './datasets-display.component.html',
     styleUrls: ['./datasets-display.component.scss']
 })
-export class DatasetsDisplayComponent implements OnInit {
+export class DatasetsDisplayComponent {
 
     @Input() registries: any = [];
     @Input() cswRecordList: CSWRecordModel[] = [];
@@ -25,21 +25,11 @@ export class DatasetsDisplayComponent implements OnInit {
 
     @Output() bookMarkChoice = new EventEmitter();
 
-    // Store opacities so slider remembers position when paging
-    layerOpacities: Map<String, number> = new Map<String, number>();
-
 
     constructor(public olMapService: OlMapService,
         public cswSearchService: CSWSearchService,
         public modalService: NgbModal) { }
 
-
-    ngOnInit() {
-        this.cswRecordList.forEach(record => {
-            this.layerOpacities.set(record.id, 100);
-        });
-    }
-    
 
     /**
      *
@@ -47,7 +37,6 @@ export class DatasetsDisplayComponent implements OnInit {
      */
     public addCSWRecord(cswRecord: CSWRecordModel): void {
         try {
-            this.layerOpacities.set(cswRecord.id, 100);
             this.olMapService.addCSWRecord(cswRecord);
         } catch (error) {
             // TODO: Proper error reporting
@@ -60,18 +49,7 @@ export class DatasetsDisplayComponent implements OnInit {
      * @param recordId
      */
     public removeCSWRecord(recordId: string): void {
-        this.layerOpacities.set(recordId, 100);
         this.olMapService.removeLayer(this.olMapService.getLayerModel(recordId));
-    }
-
-    /**
-     * 
-     * @param layerId 
-     * @param opacity 
-     */
-    public setLayerOpacity(layerId: string, e: any) {
-        this.layerOpacities.set(layerId, e.value);
-        this.olMapService.setLayerOpacity(layerId, e.value/100);
     }
 
     /**

--- a/src/app/layout/datasets/datasets.component.html
+++ b/src/app/layout/datasets/datasets.component.html
@@ -274,19 +274,20 @@
                     <app-ol-map-zoom></app-ol-map-zoom>
                     <app-ol-boundary-select></app-ol-boundary-select>
                 </div>
+
                 <div class="btn-group" style="position:absolute;z-index:1;margin-top:40px;margin-left:4px;">
                     <!-- Select Data button -->
                     <app-ol-map-select-data></app-ol-map-select-data>
                 </div>
+
+                <div class="btn-group" style="position:absolute;z-index:1;margin-left:190px; margin-top:4px;width:250px;">
+                    <!-- Basemap drop down menu -->
+                    <app-ol-map-basemap></app-ol-map-basemap>
+                </div>
+
                 <div style="position:absolute;z-index:1;margin-top:4px;right:10px;">
-                    <div style="position:relative;z-index:2;width:400px;right:0px;">
-                        <!-- Active Layers drop down menu -->
-                        <app-ol-map-layers></app-ol-map-layers>
-                    </div>
-                    <div class="height-full" style="position:absolute;z-index:2;margin-top:4px;width:250px;right:0px;">
-                        <!-- Basemap drop down menu -->
-                        <app-ol-map-basemap></app-ol-map-basemap>
-                    </div>
+                    <!-- Active Layers drop down menu -->
+                    <app-ol-map-layers></app-ol-map-layers>
                 </div>
                 <!-- The map -->
                 <app-ol-map class="height-full width-full"></app-ol-map> 

--- a/src/app/layout/datasets/datasets.module.ts
+++ b/src/app/layout/datasets/datasets.module.ts
@@ -7,7 +7,7 @@ import { PageHeaderModule } from '../../shared';
 import { OlMapModule } from './openlayermap/olmap.module';
 import { ConfirmDatasetsModalComponent } from './confirm-datasets.modal.component';
 import { DownloadOptionsModalComponent } from './download-options.modal.component';
-import { NgbCollapseModule, NgbModalModule, NgbTypeaheadModule, NgbTabsetModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCollapseModule, NgbModalModule, NgbTypeaheadModule, NgbTabsetModule } from '@ng-bootstrap/ng-bootstrap';
 import { CalendarModule } from 'primeng/calendar';
 import { TableModule } from 'primeng/table';
 import { TreeTableModule } from 'primeng/treetable';
@@ -33,7 +33,6 @@ import { RemoteDatasetsModalComponent } from './remote-datasets.modal.component'
     DropdownModule,
     SliderModule,
     NgbCollapseModule.forRoot(),
-    NgbDropdownModule.forRoot(),
     NgbModalModule.forRoot(),
     NgbTypeaheadModule.forRoot(),
     NgbTabsetModule.forRoot()

--- a/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.html
+++ b/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.html
@@ -1,21 +1,20 @@
 <div class="olMapBasemapPanel">
-  <ngb-accordion #acc="ngbAccordion">
-      <ngb-panel>
-          <ng-template ngbPanelTitle>
-              <span>&nbsp;Base Map</span>
-              <i *ngIf="basemapIsCollapsed" style="line-height:inherit;" class="fa fa-toggle-down pull-right"></i>
-              <i *ngIf="!basemapIsCollapsed" style="line-height:inherit;" class="fa fa-toggle-up pull-right"></i>
-          </ng-template>
-          <ng-template ngbPanelContent>
-              <div *ngIf="baseMaps.length===0" style="padding:1.25rem;">
-                  No basemaps have been defined, using the default.
-              </div>
-              <div *ngIf="baseMaps.length>0">
-                  <div *ngFor="let baseMap of baseMaps" style="margin-bottom:2px;">
-                      <p-radioButton  (click)="onBaseMapSelection()"  name="baseMapGroup" label="{{ baseMap.viewValue }}" value="{{ baseMap.value }}" [(ngModel)]="selectedBaseMap"></p-radioButton>
-                  </div>
-              </div>
-          </ng-template>
-      </ngb-panel>
-  </ngb-accordion>
+    <button type="button" class="btn btn-sm btn-primary" title="Select base map" (click)="baseMapIsCollapsed=!baseMapIsCollapsed"
+        [attr.aria-expanded]="!baseMapIsCollapsed" aria-controls="baseMapCollapse">
+        <span class="fa fa-globe" aria-hidden="true"></span>
+    </button>
+    <div id="baseMapCollapse" [ngbCollapse]="baseMapIsCollapsed">
+        <div class="card" style="position:fixed;max-height:calc(100vh - 200px);overflow-y:auto;background-color:white;">
+            <div class="card-body">
+                <div *ngIf="baseMaps.length===0" style="padding:1.25rem;">
+                    No basemaps have been defined, using the default.
+                </div>
+                <div *ngIf="baseMaps.length>0">
+                    <div *ngFor="let baseMap of baseMaps" style="margin-bottom:2px;">
+                        <p-radioButton  (click)="onBaseMapSelection()"  name="baseMapGroup" label="{{ baseMap.viewValue }}" value="{{ baseMap.value }}" [(ngModel)]="selectedBaseMap"></p-radioButton>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.ts
@@ -26,6 +26,7 @@ export class OlMapBasemapComponent implements OnInit {
   onBaseMapSelection() {
     if(this.selectedBaseMap) {
       this.olMapService.switchBaseMap(this.selectedBaseMap);
+      this.baseMapIsCollapsed = true;
     }
   }
 

--- a/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.html
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.html
@@ -28,18 +28,28 @@
                             -->
                             <input class="input-group-text text-truncate" style="width:100%;" data-toggle="tooltip" title="{{ layer.name }}" value="{{ layer.name }}"
                                 readonly>
+
+                            <span class="input-group-append">
+                                <button class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Display layer bounds, double-click to zoom to bounds" (click)="showCSWRecordBounds(layer)"
+                                    (dblclick)="zoomToCSWRecordBounds(layer)">
+                                    <i class="fa fa-search"></i>
+                                </button>
+                            </span>
+
                             <span class="input-group-append">
                                 <button class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Click to display layer information" (click)="displayRecordInformation(layer)">
                                     <i class="fa fa-info-circle" style="color:blue;"></i>
                                 </button>
                             </span>
                             <span class="input-group-append">
-                                <button *ngIf="!layer.hidden" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Click to hide layer" (click)="toggleLayerVisibility(layer)">
-                                    <i class="fa fa-eye"></i>
-                                </button>
-                                <button *ngIf="layer.hidden" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Click to make layer visibility" (click)="toggleLayerVisibility(layer)">
-                                    <i class="fa fa-eye-slash"></i>
-                                </button>
+                                <div ngbDropdown>
+                                    <button ngbDropdownToggle class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Layer opacity">
+                                        <i class="fa fa-tint" style="color:blue;"></i>
+                                    </button>
+                                    <div ngbDropdownMenu>
+                                        <p-slider [ngModel]="layerOpacities.get(layer.id)" [min]="0" [max]="100" orientation="vertical" (onChange)="setLayerOpacity(layer.id, $event)"></p-slider>
+                                    </div>
+                                </div>
                             </span>
                             <span class="input-group-append">
                                 <button class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Remove layer from map" (click)="removeRecord(layer.id)">

--- a/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.scss
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.scss
@@ -25,4 +25,19 @@
             padding-bottom: 0px;
         }
     }
+
+    // Remove opacity Dropdown arrow
+    .dropdown-toggle::after {
+        display:none;
+    }
+  
+    .dropdown-menu {
+        min-width: 25px;
+    }
+  
+    p-slider {
+        display: flex;
+        justify-content: center;
+    }
+  
 }

--- a/src/app/layout/datasets/openlayermap/olmap.module.ts
+++ b/src/app/layout/datasets/openlayermap/olmap.module.ts
@@ -8,18 +8,22 @@ import { OlMapZoomComponent } from './controls/olmap.zoom.component';
 import { OlMapDataSelectComponent } from './controls/olmap.select.data.component';
 import { OlMapLayersComponent } from './controls/olmap.layers.component';
 import { OlMapBoundariesComponent } from './controls/olmap.boundaries.component';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbAccordionModule, NgbDropdownModule, NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { OlMapBasemapComponent } from './controls/ol-map-basemap.component';
 import { RadioButtonModule } from 'primeng/radiobutton';
+import { SliderModule } from 'primeng/slider';
 
 
 @NgModule({
   imports: [
     CommonModule,
-    NgbModule.forRoot(),
+    NgbAccordionModule.forRoot(),
+    NgbCollapseModule.forRoot(),
+    NgbDropdownModule.forRoot(),
     ReactiveFormsModule,
     FormsModule,
-    RadioButtonModule
+    RadioButtonModule,
+    SliderModule
   ],
   declarations: [ OlMapComponent, OlMapPreviewComponent, OlMapZoomComponent, OlMapDataSelectComponent, OlMapLayersComponent, OlMapBoundariesComponent, OlMapBasemapComponent ],
   bootstrap: [ OlMapComponent, OlMapPreviewComponent, OlMapZoomComponent, OlMapDataSelectComponent, OlMapLayersComponent, OlMapBoundariesComponent, OlMapBasemapComponent ],


### PR DESCRIPTION
* Changed basemap dropdown to a button to reduce size and it can no longer disappear off the bottom of the panel.
* Removed layer visibility button from active layers dropdown to reduce clutter and functionality can be achieved with opacity slider.
* Reduced width of active layer dropdown slightly when not opened.