### PR TITLE
AUS-3438 update gsky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+/.history
 
 # IDE - VSCode
 .vscode/*

--- a/src/app/layout/datasets/datasets-record/datasets-record.component.html
+++ b/src/app/layout/datasets/datasets-record/datasets-record.component.html
@@ -1,40 +1,21 @@
 <div class="dataset-record">
     <div class="input-group input-group-sm" style="padding: 0px;border-bottom: 1px solid gray;">
         <span class="input-group-prepend" style="display:flex">
-            <!-- Indent GSKY layers -->
-            <div *ngIf="isGskyLayer" style="width:28px;"></div>
             <!-- Don't display add layer buttons if this is a map control -->
             <div *ngIf="!isMapControl">
                 <!-- Record can not be added -->
-                <button *ngIf="!isAddableRecord(cswRecord) && !isExpandableRecord(cswRecord) && !olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip"
+                <button *ngIf="!isAddableRecord(cswRecord) && !olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip"
                     title="Layer has no appropriate online resources and as such, cannot be added">
                     <i class="fa fa-times"></i>
                 </button>
-                <!-- Add layer to map, or load child layers (GSKY) -->
-                <button *ngIf="isAddableRecord(cswRecord) && !isExpandableRecord(cswRecord) && !hasChildRecords(cswRecord) && !areLayersLoading(cswRecord.id)"
+                <!-- Add layer to map -->
+                <button *ngIf="isAddableRecord(cswRecord)"
                     class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Add layer to map"
                     (click)="addCSWRecord(cswRecord)">
                     <i class="fa fa-plus-circle" style="color:green;"></i>
                 </button>
-                <!-- Load child layers (GSKY) -->
-                <button *ngIf="isExpandableRecord(cswRecord) && !hasChildRecords(cswRecord) && !areLayersLoading(cswRecord.id)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Load layers"
-                    (click)="addCSWRecord(cswRecord)">
-                    <i class="fa fa-list-alt" style="color:green;"></i>
-                </button>
-                <!-- Loading child layers (GSKY parent) -->
-                <button *ngIf="areLayersLoading(cswRecord.id)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Loading layers...">
-                    <i class="fa fa-spinner fa-spin"></i>
-                </button>
-                <!-- Child layers (GSKY children) are being displayed, button will collapse children -->
-                <button *ngIf="hasChildRecords(cswRecord)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Collapse layers"
-                    (click)="removeChildRecords(cswRecord)">
-                    <i class="fa fa-angle-double-up" style="color:red;"></i>
-                </button>
             </div>
-            <!-- Layer (non-GSKY) displayed, button will remove from map -->
+            <!-- Layer displayed, button will remove from map -->
             <button *ngIf="olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Remove layer from map"
                 (click)="removeCSWRecord(cswRecord.id)">
                 <i class="fa fa-trash" style="color:red;"></i>
@@ -60,7 +41,7 @@
                 </div>
             </div>
             <!-- Bookmarks -->
-            <div *ngIf="!isMapControl && !isGskyLayer">
+            <div *ngIf="!isMapControl">
                 <button *ngIf="validUser && !isBookMark(cswRecord)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Bookmark as favourite" (click)="addBookMark(cswRecord)">
                     <i class="fa fa-heart-o" style="color:red;"></i>
                 </button>

--- a/src/app/layout/datasets/datasets-record/datasets-record.component.ts
+++ b/src/app/layout/datasets/datasets-record/datasets-record.component.ts
@@ -26,14 +26,10 @@ export class DatasetsRecordComponent {
     @Input() validUser: boolean = false;
     // Map controls will not have an add layer button, and will have a transparency button
     @Input() isMapControl: boolean = false;
-    @Input() isGskyLayer: boolean = false;
     @Output() bookMarkChoice = new EventEmitter();
 
     // Layer opacity only relevant to map control layer list
     layerOpacity: number = 100;
-
-    // Keep track of GSKY (or other) layers that may currently be loading
-    private layersLoading: Map<string, boolean> = new Map<string, boolean>();
 
     // Keep track of time extents that may be loading via GetCap requests
     public timeExtentStatus: string;
@@ -48,42 +44,27 @@ export class DatasetsRecordComponent {
                 public activeModal: NgbActiveModal) { }
 
     /**
-     *
-     * @param cswRecord
+     * Add CSW record layer to the map
+     * @param cswRecord CSW record to add to map as layer
      */
     public addCSWRecord(cswRecord: CSWRecordModel): void {
-        if (this.isExpandableRecord(cswRecord)) {
-            this.loadExpandedLayers(cswRecord);
-        } else {
-            try {
-                // Clone the record before adding in case we need to modify details for GSKY records
-                let clonedRecord = JSON.parse(JSON.stringify(cswRecord));
-
-                // Check online resources to see if protocol request has been set
-                // denoting a specific layer of the WMS/WCS etc. and rebuild URL
-                for (let resource of clonedRecord.onlineResources) {
-                    // WMS
-                    if (this.isGetCapabilitiesUrl(resource.url, 'wms') && resource.protocolRequest != "") {
-                        resource.name = resource.protocolRequest;
-                        // TODO: Stricter URL rewriting
-                        resource.url = resource.url.substring(0, resource.url.indexOf('?') + 1) + "service=WMS";
-                    } else if ((this.isGetCapabilitiesUrl(resource.url, 'wcs') /*|| resource.type.toLowerCase() == 'ncss'*/) && resource.protocolRequest != "") {
-                        resource.name = resource.protocolRequest;
-                    }
-                    // TODO: WFS?
-
+        let onlineResources: OnlineResourceModel[] = cswRecord.onlineResources;
+        if (onlineResources && onlineResources.length > 0) {
+            const wmsResourceIndex = onlineResources.findIndex(r => r.type === 'WMS');
+            if (wmsResourceIndex !== -1 && this.isGetCapabilitiesUrl(onlineResources[wmsResourceIndex].url, 'wms')) {
+                let wcsResourceIndex = onlineResources.findIndex(r => r.type === 'WCS');
+                if (wcsResourceIndex !== -1 && this.isGetCapabilitiesUrl(onlineResources[wcsResourceIndex].url, 'wcs')) {
+                    onlineResources[wmsResourceIndex].url = onlineResources[wmsResourceIndex].url.substring(0, onlineResources[wmsResourceIndex].url.indexOf('?') + 1) + "service=WMS";
+                    onlineResources[wcsResourceIndex].url = onlineResources[wcsResourceIndex].url.substring(0, onlineResources[wcsResourceIndex].url.indexOf('?') + 1) + "service=WCS";
                 }
-                this.olMapService.addCSWRecord(clonedRecord);
-            } catch (error) {
-                // TODO: Proper error reporting
-                alert(error.message);
             }
         }
+        this.olMapService.addCSWRecord(cswRecord);
     }
 
     /**
-     *
-     * @param recordId
+     * Remove the layer for the CSW record from the map
+     * @param recordId ID of CSW record to remove
      */
     public removeCSWRecord(recordId: string): void {
         this.olMapService.removeLayer(this.olMapService.getLayerModel(recordId));
@@ -92,8 +73,8 @@ export class DatasetsRecordComponent {
     }
 
     /**
-     *
-     * @param cswRecord
+     * Display the record information dialog
+     * @param cswRecord CSW record for information
      */
     public displayRecordInformation(cswRecord) {
         if (cswRecord) {
@@ -103,8 +84,8 @@ export class DatasetsRecordComponent {
     }
 
     /**
-     *
-     * @param cswRecord
+     * Show the bounds for the layer correspondng to the supplied CSW record
+     * @param cswRecord CSW record for bounds
      */
     public showCSWRecordBounds(cswRecord: CSWRecordModel): void {
         if (cswRecord.geographicElements.length > 0) {
@@ -117,7 +98,7 @@ export class DatasetsRecordComponent {
     }
 
     /**
-     *
+     * Zoom the map to the bounds of the layer for the given CSW record.
      * @param cswRecord
      */
     public zoomToCSWRecordBounds(cswRecord: CSWRecordModel): void {
@@ -168,21 +149,12 @@ export class DatasetsRecordComponent {
     /**
      * Determine if a CSWRecord meets the criteria to be added to the map.
      *
-     * For a standard layer:
+     * Will return true if layer satisfies:
      *
      *   1. Has online resource.
      *   2. Has at least one defined geographicElement.
      *   3. Layer does not already exist on map.
      *   4. One online resource is of type WMS, WFS, CSW or WWW.
-     *
-     * For a GSKY layer:
-     *
-     *   1. WMS endpoint exists as a GetCapabilities URL, and a protocolRequest
-     *      value is present.
-     *   2. Some other online resource that can be downloaded is present,
-     *      currently one of:
-     *      - WCS GetCapabilities with a protocolRequest value set.
-     *      - NetCDF endpoint with a protocolRequest value set.
      *
      * @param cswRecord the CSWRecord to verify
      * @return true is CSWRecord can be added, false otherwise
@@ -196,43 +168,8 @@ export class DatasetsRecordComponent {
                 cswRecord.geographicElements.length > 0 &&
                 !this.olMapService.layerExists(cswRecord.id)) {
             addable = true;
-            // GSKY checks - If resource is a WMS GetCapabilities request then
-            // protocol request must be present otherwise it's expandable, not
-            // addable
-            const wmsResource: OnlineResourceModel = this.getCapabilitiesOnlineResource(cswRecord, 'wms');
-            if (wmsResource && this.isGetCapabilitiesUrl(wmsResource.url, "wms") && wmsResource.protocolRequest && wmsResource.protocolRequest == "") {
-                addable = false;
-            }
         }
         return addable;
-    }
-
-    /**
-     * Determine if record is expandable. That is, instead of being added to
-     * the map it's queried to display sub-layers (e.g. a WMS GetCapabilities
-     * endpoint).
-     *
-     * TODO: stricter checks.
-     *
-     * If both conditions are met:
-     *   - Has a WMS OnlineResourceModel with a GetCapabilities URL and NO protocolRequest value.
-     *   - Has a WCS OnlineResourceModel with a GetCapabilities URL and NO protocolRequest value.
-     *
-     * @param cswRecord
-     */
-    public isExpandableRecord(cswRecord: CSWRecordModel): boolean {
-        const wmsResource: OnlineResourceModel = this.getCapabilitiesOnlineResource(cswRecord, 'wms');
-        const wcsResource: OnlineResourceModel = this.getCapabilitiesOnlineResource(cswRecord, 'wcs');
-        return wmsResource != null && (wmsResource.protocolRequest == null || wmsResource.protocolRequest.trim() == "") &&
-               wcsResource != null && (wcsResource.protocolRequest == null || wcsResource.protocolRequest.trim() == "");
-    }
-
-    /**
-     *
-     * @param layerId
-     */
-    public areLayersLoading(layerId: string): boolean {
-        return this.layersLoading.get(layerId) == true;
     }
 
     /**
@@ -242,32 +179,6 @@ export class DatasetsRecordComponent {
      */
     public isRecordAddedToMap(cswRecord: CSWRecordModel): boolean {
         return this.olMapService.layerExists(cswRecord.id);
-    }
-
-    /**
-     * Return true if a CSWRecordModel has child records.
-     * Currently the only indicator of GSKY records.
-     *
-     * @param cswRecord
-     */
-    public hasChildRecords(cswRecord: CSWRecordModel): boolean {
-        if (cswRecord.hasOwnProperty('childRecords') &&
-           cswRecord.childRecords != null &&
-           cswRecord.childRecords.length > 0) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Remove all child records from a particular record
-     *
-     * @param cswRecord
-     */
-    public removeChildRecords(cswRecord: CSWRecordModel) {
-        if (cswRecord.hasOwnProperty('childRecords')) {
-            cswRecord.childRecords = [];
-        }
     }
 
     /**
@@ -305,44 +216,6 @@ export class DatasetsRecordComponent {
         return null;
     }
 
-
-    /**
-     * Retrieve a GSKY record's layers and add them to the record as child records
-     *
-     * @param cswRecord
-     */
-    loadExpandedLayers(cswRecord: CSWRecordModel) {
-        this.layersLoading.set(cswRecord.id, true);
-        const wmsGetCapResource: OnlineResourceModel = this.getCapabilitiesOnlineResource(cswRecord, 'wms');
-        const wcsGetCapResource: OnlineResourceModel = this.getCapabilitiesOnlineResource(cswRecord, 'wcs');
-        if (wmsGetCapResource != null && wcsGetCapResource != null) {
-            // Construct a corresponding WCS record for each layer in the WMS
-            this.vglService.getCustomLayerRecords(wmsGetCapResource.url).subscribe((response: CSWRecordModel[]) => {
-                for (let layer of response) {
-                    let wcsOnlineResource: OnlineResourceModel = {
-                        applicationProfile: layer.onlineResources[0].applicationProfile,
-                        description: layer.onlineResources[0].description,
-                        // TODO: Check custom layer response, use csw record bounds if none
-                        geographicElements: layer.onlineResources[0].geographicElements,
-                        // geographicElements: cswRecord.geographicElements,
-                        name: layer.onlineResources[0].name,
-                        type: 'WCS',
-                        url: wcsGetCapResource.url,
-                        // TODO: from GetCapabilities <WCS_Capabilities ... version="1.0.0"> OR DescribeCoverage <CoverageDescription ... version="1.0.0.">
-                        version: '',
-                        protocolRequest: layer.onlineResources[0].protocolRequest
-                    };
-                    layer.onlineResources.push(wcsOnlineResource);
-                    cswRecord.childRecords.push(layer);
-                }
-            }, error => {
-                // TODO: Do something
-            }, () => {
-                this.layersLoading.set(cswRecord.id, false);
-            });
-        }
-    }
-
     /**
      *
      * @param layerId
@@ -360,7 +233,7 @@ export class DatasetsRecordComponent {
         if (this.cswRecord.temporalExtent &&
             this.cswRecord.temporalExtent.beginPosition &&
             this.cswRecord.temporalExtent.endPosition &&
-            this.cswRecord.temporalExtent.beginPosition != this.cswRecord.temporalExtent.endPosition) {
+            this.cswRecord.temporalExtent.beginPosition !== this.cswRecord.temporalExtent.endPosition) {
                 return true;
             }
     }

--- a/src/app/layout/datasets/datasets.component.html
+++ b/src/app/layout/datasets/datasets.component.html
@@ -227,13 +227,7 @@
                                                                         <div class="col" style="padding: 0px;">
                                                                             <li *ngFor="let cswRecord of cswSearchResults.get(registry.key)">
                                                                                 <app-datasets-record [validUser]="isValidUser()" [cswRecord]="cswRecord" 
-                                                                                    (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="false"></app-datasets-record>
-                                                                                <div *ngIf="hasChildRecords(cswRecord)">
-                                                                                    <div *ngFor="let layer of cswRecord.childRecords">
-                                                                                            <app-datasets-record [validUser]="isValidUser()" [cswRecord]="layer" 
-                                                                                            (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="true"></app-datasets-record>
-                                                                                    </div>
-                                                                                </div>
+                                                                                    (bookMarkChoice)="onBookMarkChoice($event)"></app-datasets-record>
                                                                             </li>
                                                                         </div>
                                                                     </div>
@@ -274,13 +268,7 @@
                                         <div class="col" style="padding: 0px;">
                                             <li *ngFor="let cswRecord of bookMarkCSWRecords">
                                                 <app-datasets-record [validUser]="isValidUser()" [cswRecord]="cswRecord" 
-                                                    (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="false"></app-datasets-record>
-                                                    <div *ngIf="hasChildRecords(cswRecord)">
-                                                        <div *ngFor="let layer of cswRecord.childRecords">
-                                                                <app-datasets-record [validUser]="isValidUser()" [cswRecord]="layer" 
-                                                                (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="true"></app-datasets-record>
-                                                        </div>
-                                                    </div>
+                                                    (bookMarkChoice)="onBookMarkChoice($event)"></app-datasets-record>
                                             </li>
                                         </div>
                                     </div>

--- a/src/app/layout/datasets/datasets.component.ts
+++ b/src/app/layout/datasets/datasets.component.ts
@@ -614,21 +614,6 @@ export class DatasetsComponent implements OnInit, AfterViewChecked {
     }
 
     /**
-     * Return true if a CSWRecordModel has child records.
-     * Currently the only indicator of GSKY parent records.
-     *
-     * @param cswRecord
-     */
-    public hasChildRecords(cswRecord: CSWRecordModel): boolean {
-        if (cswRecord.hasOwnProperty('childRecords') &&
-           cswRecord.childRecords != null &&
-           cswRecord.childRecords.length > 0) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * TODO: This is used elsewhere, should make a map service method
      */
     public getActiveLayerCount(): number {


### PR DESCRIPTION
GSKY layers now use gmd:name for layer names, and remove unneeded GSKY child layer functionality.