### PR TITLE
Remove Deprecated GSKY funcitonality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+/.history
 
 # IDE - VSCode
 .vscode/*

--- a/src/app/layout/datasets/datasets-record/datasets-record.component.html
+++ b/src/app/layout/datasets/datasets-record/datasets-record.component.html
@@ -1,40 +1,21 @@
 <div class="dataset-record">
     <div class="input-group input-group-sm" style="padding: 0px;border-bottom: 1px solid gray;">
         <span class="input-group-prepend" style="display:flex">
-            <!-- Indent GSKY layers -->
-            <div *ngIf="isGskyLayer" style="width:28px;"></div>
             <!-- Don't display add layer buttons if this is a map control -->
             <div *ngIf="!isMapControl">
                 <!-- Record can not be added -->
-                <button *ngIf="!isAddableRecord(cswRecord) && !isExpandableRecord(cswRecord) && !olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip"
+                <button *ngIf="!isAddableRecord(cswRecord) && !olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip"
                     title="Layer has no appropriate online resources and as such, cannot be added">
                     <i class="fa fa-times"></i>
                 </button>
-                <!-- Add layer to map, or load child layers (GSKY) -->
-                <button *ngIf="isAddableRecord(cswRecord) && !isExpandableRecord(cswRecord) && !hasChildRecords(cswRecord) && !areLayersLoading(cswRecord.id)"
+                <!-- Add layer to map -->
+                <button *ngIf="isAddableRecord(cswRecord)"
                     class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Add layer to map"
                     (click)="addCSWRecord(cswRecord)">
                     <i class="fa fa-plus-circle" style="color:green;"></i>
                 </button>
-                <!-- Load child layers (GSKY) -->
-                <button *ngIf="isExpandableRecord(cswRecord) && !hasChildRecords(cswRecord) && !areLayersLoading(cswRecord.id)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Load layers"
-                    (click)="addCSWRecord(cswRecord)">
-                    <i class="fa fa-list-alt" style="color:green;"></i>
-                </button>
-                <!-- Loading child layers (GSKY parent) -->
-                <button *ngIf="areLayersLoading(cswRecord.id)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Loading layers...">
-                    <i class="fa fa-spinner fa-spin"></i>
-                </button>
-                <!-- Child layers (GSKY children) are being displayed, button will collapse children -->
-                <button *ngIf="hasChildRecords(cswRecord)"
-                    class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Collapse layers"
-                    (click)="removeChildRecords(cswRecord)">
-                    <i class="fa fa-angle-double-up" style="color:red;"></i>
-                </button>
             </div>
-            <!-- Layer (non-GSKY) displayed, button will remove from map -->
+            <!-- Layer displayed, button will remove from map -->
             <button *ngIf="olMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Remove layer from map"
                 (click)="removeCSWRecord(cswRecord.id)">
                 <i class="fa fa-trash" style="color:red;"></i>
@@ -60,7 +41,7 @@
                 </div>
             </div>
             <!-- Bookmarks -->
-            <div *ngIf="!isMapControl && !isGskyLayer">
+            <div *ngIf="!isMapControl">
                 <button *ngIf="validUser && !isBookMark(cswRecord)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Bookmark as favourite" (click)="addBookMark(cswRecord)">
                     <i class="fa fa-heart-o" style="color:red;"></i>
                 </button>

--- a/src/app/layout/datasets/datasets.component.html
+++ b/src/app/layout/datasets/datasets.component.html
@@ -227,17 +227,10 @@
                                                                         <div class="col" style="padding: 0px;">
                                                                             <li *ngFor="let cswRecord of cswSearchResults.get(registry.key)">
                                                                                 <app-datasets-record [validUser]="isValidUser()" [cswRecord]="cswRecord" 
-                                                                                    (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="false"></app-datasets-record>
-                                                                                <div *ngIf="hasChildRecords(cswRecord)">
-                                                                                    <div *ngFor="let layer of cswRecord.childRecords">
-                                                                                            <app-datasets-record [validUser]="isValidUser()" [cswRecord]="layer" 
-                                                                                            (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="true"></app-datasets-record>
-                                                                                    </div>
-                                                                                </div>
+                                                                                    (bookMarkChoice)="onBookMarkChoice($event)"></app-datasets-record>
                                                                             </li>
                                                                         </div>
                                                                     </div>
-
                                                                     <div class="row" *ngIf="!registry.value.searching" style="bottom:0;right:0px;">
                                                                         <div class="col">
                                                                             <button [disabled]="!hasNextResultsPage(registry.key)" class="btn btn-sm pull-right" style="margin-left:2px;" data-toggle="tooltip" title="Next page"
@@ -274,13 +267,7 @@
                                         <div class="col" style="padding: 0px;">
                                             <li *ngFor="let cswRecord of bookMarkCSWRecords">
                                                 <app-datasets-record [validUser]="isValidUser()" [cswRecord]="cswRecord" 
-                                                    (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="false"></app-datasets-record>
-                                                    <div *ngIf="hasChildRecords(cswRecord)">
-                                                        <div *ngFor="let layer of cswRecord.childRecords">
-                                                                <app-datasets-record [validUser]="isValidUser()" [cswRecord]="layer" 
-                                                                (bookMarkChoice)="onBookMarkChoice($event)" [isGskyLayer]="true"></app-datasets-record>
-                                                        </div>
-                                                    </div>
+                                                    (bookMarkChoice)="onBookMarkChoice($event)"></app-datasets-record>
                                             </li>
                                         </div>
                                     </div>

--- a/src/app/layout/datasets/datasets.component.ts
+++ b/src/app/layout/datasets/datasets.component.ts
@@ -614,21 +614,6 @@ export class DatasetsComponent implements OnInit, AfterViewChecked {
     }
 
     /**
-     * Return true if a CSWRecordModel has child records.
-     * Currently the only indicator of GSKY parent records.
-     *
-     * @param cswRecord
-     */
-    public hasChildRecords(cswRecord: CSWRecordModel): boolean {
-        if (cswRecord.hasOwnProperty('childRecords') &&
-           cswRecord.childRecords != null &&
-           cswRecord.childRecords.length > 0) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * TODO: This is used elsewhere, should make a map service method
      */
     public getActiveLayerCount(): number {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,14 @@
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
 
+"@turf/boolean-point-in-polygon@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz#5836677afd77d2ee391af0056a0c29b660edfa32"
+  integrity sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
 "@turf/center@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-6.0.1.tgz#40a17d0a170df5bba09ad93e133b904d8eb14601"
@@ -1267,6 +1275,13 @@
   integrity sha1-MRk8fxQpRpv6oWxmhfVCNOWRMaA=
   dependencies:
     "@turf/invariant" "^5.0.0"
+
+"@turf/invariant@6.x":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
+  integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/invariant@^5.0.0":
   version "5.2.0"


### PR DESCRIPTION
Remove GSKY functionality that is no longer required due to how GSKY layers are now implemented, mostly due to layer names now being stored in gmd:name rather than gmd:protocalRequest. Most functionality still required is occurring in the back-end.

Test by searching for "aster" on the NCI Portal.