### PR TITLE
Use NPM published portal-core-ui library instead of Github version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ol-geocoder": "^4.0.0",
     "plotly.js": "^1.55.1",
     "plotly.js-basic-dist": "^1.55.1",
-    "portal-core-ui": "github:AuScope/portal-core-ui#master",
+    "portal-core-ui": "^1.0.2",
     "primeicons": "4.0.0",
     "primeng": "^9.1.3",
     "rxjs": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ol-geocoder": "^4.0.0",
     "plotly.js": "^1.55.1",
     "plotly.js-basic-dist": "^1.55.1",
-    "portal-core-ui": "^1.0.2",
+    "portal-core-ui": "^1.0.3",
     "primeicons": "4.0.0",
     "primeng": "^9.1.3",
     "rxjs": "^6.6.3",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CustomReuseStrategy } from './app-custom-reuse-strategy';
 import { AuthGuard, AuthService } from './shared';
-import { PortalCoreModule } from 'portal-core-ui/portal-core.module';
+import { PortalCoreModule } from 'portal-core-ui';
 import { UserStateService } from './shared';
 import { VglModule } from './shared';
 import { UserModule } from './layout/user/user.module';

--- a/src/app/layout/components/sidebar/sidebar.component.ts
+++ b/src/app/layout/components/sidebar/sidebar.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { UserStateService, ViewType } from '../../../shared';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
+import { OlMapService } from 'portal-core-ui';
 
 @Component({
     selector: 'app-sidebar',

--- a/src/app/layout/datasets/confirm-datasets.modal.component.ts
+++ b/src/app/layout/datasets/confirm-datasets.modal.component.ts
@@ -4,7 +4,7 @@ import { DownloadOptionsModalComponent } from './download-options.modal.componen
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TreeNode } from 'primeng/api';
 import { UserStateService } from '../../shared';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel } from 'portal-core-ui';
 import { CSWSearchService } from '../../shared/services/csw-search.service';
 import { VglService } from '../../shared/modules/vgl/vgl.service';
 import { forkJoin } from 'rxjs/observable/forkJoin';

--- a/src/app/layout/datasets/datasets-record/datasets-record.component.ts
+++ b/src/app/layout/datasets/datasets-record/datasets-record.component.ts
@@ -1,12 +1,10 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel, OlMapService, OnlineResourceModel } from 'portal-core-ui';
 import { BookMark } from '../../../shared/modules/vgl/models';
 import { RecordModalComponent } from '../record.modal.component';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
 import { CSWSearchService } from '../../../shared/services/csw-search.service';
 import { NgbModal, NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import * as Proj from 'ol/proj';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
 import { VglService } from '../../../shared/modules/vgl/vgl.service';
 import { StyleChooserModalComponent } from '../../../shared/modules/grace/style-chooser.modal.component';
 import { GraceStyleSettings } from '../../../shared/modules/grace/grace-graph.models';

--- a/src/app/layout/datasets/datasets.component.ts
+++ b/src/app/layout/datasets/datasets.component.ts
@@ -6,13 +6,11 @@ import { routerTransition } from '../../router.animations';
 import { AuthService, UserStateService, DATA_VIEW } from '../../shared';
 import { CSWSearchService } from '../../shared/services/csw-search.service';
 
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel, LayerModel, OlMapService } from 'portal-core-ui';
 import { BookMark, Registry } from '../../shared/modules/vgl/models';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
 import * as Proj from 'ol/proj';
 
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
-import { LayerModel } from 'portal-core-ui/model/data/layer.model';
 
 
 @Component({

--- a/src/app/layout/datasets/download-options.modal.component.ts
+++ b/src/app/layout/datasets/download-options.modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel } from 'portal-core-ui';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { DownloadOptions, DescribeCoverage } from '../../shared/modules/vgl/models';

--- a/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/ol-map-basemap.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
+import { OlMapService } from 'portal-core-ui';
 
 @Component({
   selector: 'app-ol-map-basemap',

--- a/src/app/layout/datasets/openlayermap/controls/olmap.boundaries.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.boundaries.component.ts
@@ -1,4 +1,4 @@
-import { OlMapObject } from 'portal-core-ui/service/openlayermap/ol-map-object';
+import { CSWRecordModel, OlMapObject, OlMapService } from 'portal-core-ui';
 import { OnInit, AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
 
 import { FormControl } from '@angular/forms';
@@ -18,9 +18,7 @@ import * as Proj from 'ol/proj';
 
 import { BoundaryService } from '../../../../shared/services/boundary.service';
 import { environment } from '../../../../../environments/environment';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
 
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
 import { ConfirmDatasetsModalComponent } from '../../confirm-datasets.modal.component';
 import { OlMapDataSelectComponent } from './olmap.select.data.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';

--- a/src/app/layout/datasets/openlayermap/controls/olmap.grace-data.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.grace-data.component.ts
@@ -1,11 +1,10 @@
 import { Component, AfterViewInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import * as Proj from 'ol/proj';
-import { OlMapObject } from 'portal-core-ui/service/openlayermap/ol-map-object';
+import { OlMapObject, OlMapService } from 'portal-core-ui';
 import { environment } from '../../../../../environments/environment';
 import { GraceGraphModalComponent } from '../../../../shared/modules/grace/grace-graph.modal.component';
 import { GraceService } from '../../../../shared/modules/grace/grace.service';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
 
 
 @Component({

--- a/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.layers.component.ts
@@ -1,5 +1,4 @@
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
-import { LayerModel } from 'portal-core-ui/model/data/layer.model';
+import { LayerModel, OlMapService } from 'portal-core-ui';
 import { Component } from '@angular/core';
 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';

--- a/src/app/layout/datasets/openlayermap/controls/olmap.select.data.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.select.data.component.ts
@@ -1,9 +1,7 @@
 import { Component } from '@angular/core';
 import { ConfirmDatasetsModalComponent } from '../../confirm-datasets.modal.component';
 import { DownloadOptions } from '../../../../shared/modules/vgl/models';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
+import { CSWRecordModel, OlMapService, OnlineResourceModel } from 'portal-core-ui';
 import { CSWSearchService } from '../../../../shared/services/csw-search.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TreeNode } from 'primeng/api';

--- a/src/app/layout/datasets/openlayermap/controls/olmap.zoom.component.ts
+++ b/src/app/layout/datasets/openlayermap/controls/olmap.zoom.component.ts
@@ -1,4 +1,4 @@
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
+import { OlMapService } from 'portal-core-ui';
 import { Component } from '@angular/core';
 
 

--- a/src/app/layout/datasets/openlayermap/olmap.component.ts
+++ b/src/app/layout/datasets/openlayermap/olmap.component.ts
@@ -1,4 +1,4 @@
-import { OlMapObject } from 'portal-core-ui/service/openlayermap/ol-map-object';
+import { OlMapObject } from 'portal-core-ui';
 import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
 
 /*

--- a/src/app/layout/datasets/openlayermap/olmap.preview.component.ts
+++ b/src/app/layout/datasets/openlayermap/olmap.preview.component.ts
@@ -1,7 +1,4 @@
-import { OlMapObject } from 'portal-core-ui/service/openlayermap/ol-map-object';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
-import { RenderStatusService } from 'portal-core-ui/service/openlayermap/renderstatus/render-status.service';
-import { Constants } from 'portal-core-ui/utility/constants.service';
+import { Constants, OlMapObject, OlMapService, RenderStatusService } from 'portal-core-ui';
 import { AfterViewInit, Component, ElementRef, ViewChild, Inject } from '@angular/core';
 import { point, polygon } from '@turf/helpers';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';

--- a/src/app/layout/datasets/record.modal.component.ts
+++ b/src/app/layout/datasets/record.modal.component.ts
@@ -1,11 +1,10 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel, OnlineResourceModel } from 'portal-core-ui';
 import { RemoteDatasetsModalComponent } from './remote-datasets.modal.component';
 import { UserStateService } from '../../shared';
 import { CSWSearchService } from '../../shared/services/csw-search.service';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
 
 
 @Component({

--- a/src/app/layout/job-wizard/job-datasets.component.ts
+++ b/src/app/layout/job-wizard/job-datasets.component.ts
@@ -10,7 +10,7 @@ import { saveAs } from 'file-saver';
 import { VglService } from '../../shared/modules/vgl/vgl.service';
 import { CSWSearchService } from '../../shared/services/csw-search.service';
 import { RemoteDatasetsModalComponent } from '../datasets/remote-datasets.modal.component';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
+import { OnlineResourceModel } from 'portal-core-ui';
 
 
 @Component({

--- a/src/app/layout/layout.module.ts
+++ b/src/app/layout/layout.module.ts
@@ -1,4 +1,4 @@
-import { PortalCorePipesModule } from 'portal-core-ui/uiutilities/portal-core.pipes.module';
+import { PortalCorePipesModule } from 'portal-core-ui';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,8 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { routerTransition } from '../router.animations';
 
 import { UserStateService } from '../shared';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
-import { LayerModel } from 'portal-core-ui/model/data/layer.model';
+import { LayerModel, OlMapService } from 'portal-core-ui';
 
 import { environment } from '../../environments/environment';
 

--- a/src/app/shared/modules/vgl/models.ts
+++ b/src/app/shared/modules/vgl/models.ts
@@ -1,5 +1,4 @@
-import { CSWRecordModel } from "portal-core-ui/model/data/cswrecord.model";
-import { OnlineResourceModel } from "portal-core-ui/model/data/onlineresource.model";
+import { CSWRecordModel, OnlineResourceModel } from "portal-core-ui";
 
 /*
  * User Models

--- a/src/app/shared/modules/vgl/vgl.service.ts
+++ b/src/app/shared/modules/vgl/vgl.service.ts
@@ -5,7 +5,7 @@ import { Observable, of, throwError, forkJoin, EMPTY } from 'rxjs';
 import { switchMap, map, defaultIfEmpty } from 'rxjs/operators';
 
 import { Job, Problem, Problems, Solution, User, TreeJobs, Series, CloudFileInformation, DownloadOptions, JobDownload, NCIDetails, BookMark, ComputeService, MachineImage, ComputeType, Entry, DescribeCoverage } from './models';
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
+import { CSWRecordModel } from 'portal-core-ui';
 
 import { environment } from '../../../../environments/environment';
 

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -4,8 +4,7 @@ import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { UserStateService } from './user-state.service';
 import { ANONYMOUS_USER, JobDownload } from '../modules/vgl/models';
-import { OlMapService } from 'portal-core-ui/service/openlayermap/ol-map.service';
-import { LayerModel } from 'portal-core-ui/model/data/layer.model';
+import { LayerModel, OlMapService } from 'portal-core-ui';
 import { environment } from '../../../environments/environment';
 
 @Injectable()

--- a/src/app/shared/services/csw-search.service.ts
+++ b/src/app/shared/services/csw-search.service.ts
@@ -4,12 +4,10 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/Rx';
 
-import { CSWRecordModel } from 'portal-core-ui/model/data/cswrecord.model';
-import { OnlineResourceModel } from 'portal-core-ui/model/data/onlineresource.model';
+import { CSWRecordModel, LayerHandlerService, OnlineResourceModel } from 'portal-core-ui';
 import { BookMark, Registry, DownloadOptions, JobDownload } from '../../shared/modules/vgl/models';
 import { VglService } from '../../shared/modules/vgl/vgl.service';
 import { UserStateService } from './user-state.service';
-import { LayerHandlerService } from 'portal-core-ui/service/cswrecords/layer-handler.service';
 
 
 @Injectable({

--- a/yarn.lock
+++ b/yarn.lock
@@ -10056,10 +10056,10 @@ polytope-closest-point@^1.0.0:
   dependencies:
     numeric "^1.2.6"
 
-portal-core-ui@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/portal-core-ui/-/portal-core-ui-1.0.2.tgz#6c58d588e54c89cb51f7a8db0b36d4ed5f7d3e01"
-  integrity sha512-agyLaXZUTFFFU5u8q6KUgYrw0gOk4KLTc+pJJUg8lhoSdcJ2qTDKg9vm+OVnTAo4n433qFtJ+MijTiWvRtSWGA==
+portal-core-ui@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/portal-core-ui/-/portal-core-ui-1.0.3.tgz#1a146d585b3550e61f69ec8866adf77e147e0bfc"
+  integrity sha512-ieaazWlF2ENv+ub6Ncsl7MeRv5gzgufGPxcwmbzX9oiCNNMGstTrZpomOXz6SfMrG5Na/CAJ4kfBMe5TzSx75w==
   dependencies:
     tslib "^1.10.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10056,9 +10056,12 @@ polytope-closest-point@^1.0.0:
   dependencies:
     numeric "^1.2.6"
 
-"portal-core-ui@github:AuScope/portal-core-ui#master":
-  version "1.0.0"
-  resolved "https://codeload.github.com/AuScope/portal-core-ui/tar.gz/768e4979b36d019191840a2acabffe0a0c3e35ea"
+portal-core-ui@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/portal-core-ui/-/portal-core-ui-1.0.2.tgz#6c58d588e54c89cb51f7a8db0b36d4ed5f7d3e01"
+  integrity sha512-agyLaXZUTFFFU5u8q6KUgYrw0gOk4KLTc+pJJUg8lhoSdcJ2qTDKg9vm+OVnTAo4n433qFtJ+MijTiWvRtSWGA==
+  dependencies:
+    tslib "^1.10.0"
 
 portfinder@^1.0.26:
   version "1.0.28"


### PR DESCRIPTION
Changes the portal-core-ui library in package.json to use version 1.0.3 of the NPM published library, and changes imports to match.